### PR TITLE
Add mime types for serving static files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM nginx:1.27.0-alpine
 
+COPY ./nginx/default.conf /etc/nginx/conf.d/default.conf
 COPY assets /usr/share/nginx/html

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,17 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    location / {
+        include /etc/nginx/mime.types;
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
With these mime types, the browser can show the files inline, rather than always forcing users to download them.